### PR TITLE
Removed duplicated limit param

### DIFF
--- a/R/getCellbase-methods.R
+++ b/R/getCellbase-methods.R
@@ -37,8 +37,8 @@ setMethod("getCellBase", "CellBaseR", definition = function(object, category,
                clinsig_labels=param@clinsig_labels, 
               alleleOrigin=param@alleleOrigin, 
                consistency_labels=param@consistency_labels,
-              limit=param@limit, include=param@include,
-              exclude=param@exclude, limit=param@limit)
+              include=param@include, exclude=param@exclude,
+              limit=param@limit)
     param <- paste(param, collapse = "&")
   }
   # TODO: param are not enabled

--- a/R/getGene-methods.R
+++ b/R/getGene-methods.R
@@ -35,8 +35,8 @@ setMethod("getGene", "CellBaseR", definition = function(object, ids,
                  clinsig_labels=param@clinsig_labels, 
                  alleleOrigin=param@alleleOrigin, 
                  consistency_labels=param@consistency_labels,
-                 limit=param@limit, include=param@include,
-                 exclude=param@exclude, limit=param@limit)
+                 include=param@include, exclude=param@exclude,
+                 limit=param@limit)
         param <- paste(param, collapse = "&")
     }
     # TODO: param are not enabled

--- a/R/getProtein-methods.R
+++ b/R/getProtein-methods.R
@@ -34,8 +34,8 @@ setMethod("getProtein", "CellBaseR", definition = function(object, ids,
                  clinsig_labels=param@clinsig_labels, 
                  alleleOrigin=param@alleleOrigin, 
                  consistency_labels=param@consistency_labels,
-                 limit=param@limit, include=param@include,
-                 exclude=param@exclude, limit=param@limit)
+                 include=param@include, exclude=param@exclude,
+                 limit=param@limit)
       param <- paste(param, collapse = "&")
     }
     result <- fetchCellbase(object=object, file=NULL, meta=NULL, categ=categ, 

--- a/R/getRegion-methods.R
+++ b/R/getRegion-methods.R
@@ -31,7 +31,7 @@ setMethod("getRegion", "CellBaseR", definition = function(object, ids, resource,
     if (!is.null(param)){
       param <- c(genome=param@genome, gene=param@gene,
                    region=param@region, rs=param@rs,so=param@so,
-                   phenotype=param@phenotype, limit=param@limit, 
+                   phenotype=param@phenotype,
                    include=param@include, exclude=param@exclude,
                    limit=param@limit)
       param <- paste(param, collapse = "&")

--- a/R/getTranscript-methods.R
+++ b/R/getTranscript-methods.R
@@ -35,8 +35,8 @@ setMethod("getTranscript", "CellBaseR", definition = function(object, ids,
                  clinsig_labels=param@clinsig_labels, 
                  alleleOrigin=param@alleleOrigin, 
                  consistency_labels=param@consistency_labels,
-                 limit=param@limit, include=param@include,
-                 exclude=param@exclude, limit=param@limit)
+                 include=param@include, exclude=param@exclude,
+                 limit=param@limit)
       param <- paste(param, collapse = "&")
     }
     result <- fetchCellbase(object=object, file=NULL, meta=NULL, categ=categ,

--- a/R/getVariant-methods.R
+++ b/R/getVariant-methods.R
@@ -41,8 +41,8 @@ setMethod("getVariant", "CellBaseR", definition = function(object, ids,
                  clinsig_labels=param@clinsig_labels, 
                  alleleOrigin=param@alleleOrigin, 
                  consistency_labels=param@consistency_labels,
-                 limit=param@limit, include=param@include,
-                 exclude=param@exclude, limit=param@limit)
+                 include=param@include, exclude=param@exclude,
+                 limit=param@limit)
       param <- paste(param, collapse = "&")
       }
     

--- a/R/getXref-methods.R
+++ b/R/getXref-methods.R
@@ -36,8 +36,8 @@ setMethod("getXref", "CellBaseR", definition = function(object, ids, resource,
                  clinsig_labels=param@clinsig_labels, 
                  alleleOrigin=param@alleleOrigin, 
                  consistency_labels=param@consistency_labels,
-                 limit=param@limit, include=param@include,
-                 exclude=param@exclude, limit=param@limit)
+                 include=param@include, exclude=param@exclude,
+                 limit=param@limit)
       param <- paste(param, collapse = "&")
       }
     result <- fetchCellbase(object=object, file=NULL, meta=NULL, categ=categ,


### PR DESCRIPTION
Duplicated "limit" param causes CellBase to return an HTTP ERROR 500. And because "limit" is always populated (its value is 1000 by default), every time CellBaseParams is used in a query, it fails.

Example code to replicate the error:
```
library(cellbaseR)
cb <- CellBaseR(host="https://ws.zettagenomics.com/cellbase/webservices/rest/", version="v5", species="hsapiens")
cbparam <- CellBaseParam(assembly = 'GRCh38')
res <- getVariant(object=cb, ids=c('1:64844827:G:A'), resource="annotation", param = cbparam)
str(res, 1)
```
Error returned:
```
Error: lexical error: invalid char in json text.
                                       <html> <head> <meta http-equiv=
                     (right here) ------^
```
This PR removes duplicated "limit" param from every get function (except getClinical, which was working fine).
